### PR TITLE
Remove j-text-utils

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "overflowdb2"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.0.0"
+ThisBuild / version      := "2.0.1"
 ThisBuild / scalaVersion := "3.6.4"
 publish / skip := true
 
@@ -22,11 +22,9 @@ ThisBuild / scalacOptions ++= Seq(
 )
 
 ThisBuild / compile / javacOptions ++= Seq(
-  "-g", // debug symbols
   "-Xlint",
   "--release=21"
 ) ++ {
-  // fail early if users with JDK11 try to run this
   val javaVersion = sys.props("java.specification.version").toFloat
   assert(javaVersion.toInt >= 21, s"this build requires JDK21+ - you're using $javaVersion")
   Nil

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -2,7 +2,7 @@ name := "odb2-core"
 
 libraryDependencies ++= Seq(
   "net.sf.trove4j" % "core" % "3.1.0",
-  "org.msgpack" % "msgpack-core" % "0.9.8",
+  "org.msgpack" % "msgpack-core" % "0.9.10",
   "com.h2database" % "h2-mvstore" % "1.4.200"
 )
 githubOwner := "appthreat"

--- a/formats/build.sbt
+++ b/formats/build.sbt
@@ -2,7 +2,7 @@ name := "odb2-formats"
 
 libraryDependencies ++= Seq(
   "com.github.tototoshi" %% "scala-csv" % "2.0.0",
-  "org.scala-lang.modules" %% "scala-xml" % "2.3.0",
+  "org.scala-lang.modules" %% "scala-xml" % "2.4.0",
   "com.github.pathikrit" %% "better-files" % "3.9.2" % Test,
   "com.github.scopt" %% "scopt" % "4.1.0",
   "io.spray" %% "spray-json" % "1.3.6"

--- a/traversal/build.sbt
+++ b/traversal/build.sbt
@@ -1,8 +1,7 @@
 name := "odb2-traversal"
 
 libraryDependencies ++= Seq(
-  "org.reflections" % "reflections" % "0.10.2",
-  "com.massisframework" % "j-text-utils" % "0.3.4"
+  "org.reflections" % "reflections" % "0.10.2"
 )
 githubOwner := "appthreat"
 githubRepository := "overflowdb2"

--- a/traversal/src/main/scala/overflowdb/traversal/help/Table.scala
+++ b/traversal/src/main/scala/overflowdb/traversal/help/Table.scala
@@ -1,6 +1,5 @@
 package overflowdb.traversal.help
 
-import dnl.utils.text.table.TextTable
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.charset.StandardCharsets
 import scala.util.Using
@@ -16,3 +15,40 @@ case class Table(columnNames: Iterable[String], rows: Iterable[Iterable[String]]
             new TextTable(columnNames.toArray, rowsAsArray).printTable(ps, 0)
             new String(baos.toByteArray, charset)
         }.get
+
+class TextTable(columnNames: Array[String], data: Array[Array[Object]]):
+
+    def printTable(ps: PrintStream, indent: Int): Unit =
+        val numRows   = data.length
+        val numCols   = columnNames.length
+        val colWidths = new Array[Int](numCols)
+        for i <- columnNames.indices do
+            colWidths(i) = columnNames(i).length
+        for row <- data do
+            for i <- 0 until math.min(row.length, numCols) do
+                val cellLength = if row(i) != null then row(i).toString.length else 0
+                if cellLength > colWidths(i) then
+                    colWidths(i) = cellLength
+        printRow(ps, indent, columnNames, colWidths)
+        val separator = colWidths.map(w => "-" * w).mkString("|", "|", "|")
+        ps.println(" " * indent + separator)
+        for row <- data do
+            val stringRow = new Array[String](row.length)
+            for i <- row.indices do
+                stringRow(i) = if row(i) != null then row(i).toString else ""
+            printRow(ps, indent, stringRow, colWidths)
+    end printTable
+
+    private def printRow(
+      ps: PrintStream,
+      indent: Int,
+      row: Array[String],
+      widths: Array[Int]
+    ): Unit =
+        val paddedCells = for (i <- row.indices) yield padRight(row(i), widths(i))
+        ps.println(" " * indent + paddedCells.mkString("|", "|", "|"))
+
+    private def padRight(s: String, width: Int): String =
+        val padding = width - s.length
+        if padding > 0 then s + " " * padding else s
+end TextTable


### PR DESCRIPTION
Printing a table with rows isn't even complex and is not even required in a database library! For some reason, the upstream project was using a 12-year-old library for this.

With this PR, we remove the dependency on j-text-utils as well as updated other packages.